### PR TITLE
Add missing extension to CSV files named after community

### DIFF
--- a/application.py
+++ b/application.py
@@ -269,7 +269,7 @@ def download_csv():
     return Response(
         csv,
         mimetype="text/csv",
-        headers={"Content-disposition": "attachment; filename=" + csv_filename},
+        headers={"Content-disposition": "attachment; filename=" + csv_filename + ".csv"},
     )
 
 


### PR DESCRIPTION
STR:
- Run the app, view it in a web browser.
- Click the CSV download button below the chart.
- The downloaded CSV file should have a ".csv" extension