### PR TITLE
Fix CSV downloads for communities with special characters

### DIFF
--- a/application.py
+++ b/application.py
@@ -287,7 +287,13 @@ def download_csv():
     return Response(
         csv,
         mimetype="text/csv",
-        headers={"Content-disposition": "attachment; filename=" + csv_filename},
+        headers={
+            "Content-disposition": "attachment; filename="
+            + csv_filename
+            + "; filename*=utf-8''"
+            + csv_filename,
+            "Content-type": "text/csv;charset=utf-8",
+        },
     )
 
 

--- a/application.py
+++ b/application.py
@@ -8,6 +8,7 @@ import json
 import copy
 import os
 import urllib.request
+import urllib.parse
 import html as h
 import pandas as pd
 import dash
@@ -280,14 +281,13 @@ def download_csv():
 
     community_name = full_community_name(community)
     community_with_region = community_name + ", " + community["region"]
-    csv_filename = re.sub("[ ,]+", "_", community_with_region)
+    underscored_community = re.sub("[ ,]+", "_", community_with_region)
+    csv_filename = urllib.parse.quote(underscored_community) + ".csv"
 
     return Response(
         csv,
         mimetype="text/csv",
-        headers={
-            "Content-disposition": "attachment; filename=" + csv_filename + ".csv"
-        },
+        headers={"Content-disposition": "attachment; filename=" + csv_filename},
     )
 
 


### PR DESCRIPTION
STR:
- Select a community with special characters. For example, "Łutselkʼe, Northwest Territories" at the bottom of the dropdown list.
- Click the CSV download button below the chart.
- There should not be a server error, and the downloaded file should be named properly (special characters and all).