### PR TITLE
Content width improvements

### DIFF
--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -229,9 +229,16 @@ label.checkbox input, label.radio input {
   fill: #ccc;
 }
 
-.controls-wrapper {
+.controls-wrapper, .explanations-wrapper {
 	margin: 0 auto;
+}
+
+.controls-wrapper {
 	max-width: 60em;
+}
+
+.explanations-wrapper {
+	max-width: 50em;
 }
 
 @media (min-width: 769px) {

--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -229,6 +229,17 @@ label.checkbox input, label.radio input {
   fill: #ccc;
 }
 
+.controls-wrapper {
+	margin: 0 auto;
+	max-width: 60em;
+}
+
+@media (min-width: 769px) {
+	.form-inputs-right {
+		padding-left: 1em;
+	}
+}
+
 .footer p {
 	margin-bottom: 1em;
 	width: 90%;

--- a/gui.py
+++ b/gui.py
@@ -128,11 +128,11 @@ rcp_blurb = ddsih.DangerouslySetInnerHTML(
 )
 
 form_inputs_left = html.Div(
-    className="no-print column is-half", children=[community_selector, rcp_blurb]
+    className="no-print column is-two-thirds", children=[community_selector, rcp_blurb]
 )
 
 form_inputs_right = html.Div(
-    className="no-print column is-half",
+    className="no-print column is-one-third form-inputs-right",
     children=[dataset_radio, rcp_radio, units_radio],
 )
 
@@ -338,7 +338,7 @@ form_container = html.Div(
             className="container top",
             children=[
                 html.Div(
-                    className="columns", children=[form_inputs_left, form_inputs_right]
+                    className="columns controls-wrapper", children=[form_inputs_left, form_inputs_right]
                 )
             ],
         )

--- a/gui.py
+++ b/gui.py
@@ -188,7 +188,7 @@ explanations_download = dcc.Markdown(
 )
 
 explanations = html.Div(
-    className="container is-size-5 content",
+    className="is-size-5 content explanations-wrapper",
     children=[
         explanation_interpret,
         explanation_key_changes,


### PR DESCRIPTION
Closes #74 and #75.

The input form now uses a 2:1 column ratio, with a narrower overall width, to make things look more centered. The explanation text in the bottom half of the page is also narrower.

These changes do not affect narrow, single-column resolutions.