### PR TITLE
Round imperial/metric temperature/precipitation values to sensible precisions

### DIFF
--- a/application.py
+++ b/application.py
@@ -162,6 +162,7 @@ def update_graph(community_raw, variable, scenario, units):
                     "base": tMod,
                     "marker": {"color": "#999999"},
                     "name": "Historical ",
+                    "hovertemplate": "%{y}" + luts.unit_lu[variable][units],
                 }
             ]
         }
@@ -175,6 +176,7 @@ def update_graph(community_raw, variable, scenario, units):
                     "base": tMod,
                     "marker": {"color": df_lu[key]["color"]},
                     "name": key + " ",
+                    "hovertemplate": "%{y}" + luts.unit_lu[variable][units],
                 }
             )
         figure["layout"] = figure_layout
@@ -196,8 +198,8 @@ def update_graph(community_raw, variable, scenario, units):
             "zerolinecolor": "#efefef",
             "zerolinewidth": 0.5,
             "title": "Temperature (" + unit_lu["temp"][units] + ")",
+            "tickformat": ".{0}f".format(decimal_precision),
         }
-        figure["layout"]["yaxis"]["tickformat"] = ".{0}f".format(decimal_precision)
         figure["layout"]["shapes"] = [
             {
                 "type": "line",
@@ -226,6 +228,7 @@ def update_graph(community_raw, variable, scenario, units):
                 "type": "bar",
                 "marker": {"color": "#999999"},
                 "name": "Historical ",
+                "hovertemplate": "%{y}" + luts.unit_lu[variable][units],
             }
         ]
     }
@@ -238,6 +241,7 @@ def update_graph(community_raw, variable, scenario, units):
                 "type": "bar",
                 "marker": {"color": df_lu[key]["color"]},
                 "name": key + " ",
+                "hovertemplate": "%{y}" + luts.unit_lu[variable][units],
             }
         )
 
@@ -256,9 +260,9 @@ def update_graph(community_raw, variable, scenario, units):
         + " Scenario &nbsp;"
     )
     figure["layout"]["yaxis"] = {
-        "title": "Precipitation (" + unit_lu["precip"][units] + ")"
+        "title": "Precipitation (" + unit_lu["precip"][units] + ")",
+        "tickformat": ".{0}f".format(decimal_precision),
     }
-    figure["layout"]["yaxis"]["tickformat"] = ".{0}f".format(decimal_precision)
     return figure
 
 

--- a/application.py
+++ b/application.py
@@ -110,6 +110,18 @@ def update_graph(community_raw, variable, scenario, units):
         baseline_df[mean_cols] = (
             baseline_df[mean_cols] * imperial_conversion_lu[variable]
         )
+        if variable == "temp":
+            decimal_precision = 0
+        elif variable == "precip":
+            decimal_precision = 1
+    else:
+        if variable == "temp":
+            decimal_precision = 1
+        elif variable == "precip":
+            decimal_precision = 0
+
+    dff[mean_cols] = dff[mean_cols].round(decimal_precision)
+    baseline_df[mean_cols] = baseline_df[mean_cols].round(decimal_precision)
 
     # scenario lookup
     scenario_lu = luts.scenario_lu
@@ -185,6 +197,7 @@ def update_graph(community_raw, variable, scenario, units):
             "zerolinewidth": 0.5,
             "title": "Temperature (" + unit_lu["temp"][units] + ")",
         }
+        figure["layout"]["yaxis"]["tickformat"] = ".{0}f".format(decimal_precision)
         figure["layout"]["shapes"] = [
             {
                 "type": "line",
@@ -245,6 +258,7 @@ def update_graph(community_raw, variable, scenario, units):
     figure["layout"]["yaxis"] = {
         "title": "Precipitation (" + unit_lu["precip"][units] + ")"
     }
+    figure["layout"]["yaxis"]["tickformat"] = ".{0}f".format(decimal_precision)
     return figure
 
 


### PR DESCRIPTION
Closes #73 and #84.

STR:
- Run the app from this branch and hover over the chart bars to see their values.
- Look at the imperial & metric options for both temperature & precipitation.

Temperature values should be rounded like this:

- Imperial (Fahrenheit): No decimal places.
- Metric (Celsius): 1 decimal place

Precipitation values should be rounded like this:

- Imperial (inches): 1 decimal place
- Metric (mm): No decimal places.