### PR TITLE
Disable the ability to zoom on the chart by clicking & dragging with your mouse

### DIFF
--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -237,6 +237,10 @@ label.checkbox input, label.radio input {
 	max-width: 60em;
 }
 
+.dash-graph .js-plotly-plot .plotly .cursor-ns-resize {
+	cursor: crosshair;
+}
+
 .explanations-wrapper {
 	max-width: 50em;
 }

--- a/luts.py
+++ b/luts.py
@@ -149,6 +149,7 @@ figure_layout = {
     "margin": dict(t=100, b=130),
     "xaxis": xaxis_config,
     "yaxis": axis_configs,
+    "dragmode": False,
 }
 
 df_lu_full_temp = {


### PR DESCRIPTION
Closes #66.

The zoom buttons had already been removed from the chart, but it was still possible to click & drag on the chart to zoom. This disables that feature (while preserving the crosshair mouse cursor).

I've also removed a couple erroneous copy & paste artifacts from a previous merge that have no effect on the figure.