### PR TITLE
Make scenario text more consistent between inputs and chart, and add missing periods to text below chart

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -151,8 +151,8 @@ explanation_key_changes = dcc.Markdown(
 
     For example, higher monthly temperatures in spring and fall may be particularly interesting. Higher temperature could mean any or all of these things:
 
-    * A longer growing season
-    * A loss of ice and/or frozen ground needed for travel or food storage
+    * A longer growing season.
+    * A loss of ice and/or frozen ground needed for travel or food storage.
     * Precipitation changes. A shift from snow to rain impacts water storage capacity and surface water availability. This tool reports precipitation in terms of rainwater equivalent, even though it could occur as rain or snow.
     * Increased fire risk. In many locations, winter temperatures are projected to increase dramatically.
     * Changes in species composition. Warmer winters may favor species that are less cold-hardy (including desirable crops and invasive species), or it may mean less snow and/or more rain-on-snow events that impact wildlife.

--- a/luts.py
+++ b/luts.py
@@ -101,7 +101,7 @@ imperial_conversion_lu = {"temp": 1.8, "precip": 0.0393701}
 
 scenario_lu = {
     "rcp45": "Low Emissions (RCP 4.5)",
-    "rcp60": "Mid Emissions (RCP 6.0)",
+    "rcp60": "Medium Emissions (RCP 6.0)",
     "rcp85": "High Emissions (RCP 8.5)",
 }
 
@@ -174,7 +174,7 @@ units_radio_options = [
 ]
 
 rcp_radio_options = [
-    {"label": " Low Emissions (RCP4.5)", "value": "rcp45"},
-    {"label": " Medium Emissions (RCP6.0)", "value": "rcp60"},
-    {"label": " High Emissions (RCP8.5)", "value": "rcp85"},
+    {"label": " Low Emissions (RCP 4.5)", "value": "rcp45"},
+    {"label": " Medium Emissions (RCP 6.0)", "value": "rcp60"},
+    {"label": " High Emissions (RCP 8.5)", "value": "rcp85"},
 ]


### PR DESCRIPTION
Closes #69 and #71.

This PR:

- Updates the chart title to say "Middle Emissions" instead of "Mid Emissions" to match the scenarios radio button.
- Adds a space between "RCP" and "#.#" on the radio buttons to match the chart.
- Adds missing periods to the end of two bullet points under "Look for key changes" section.