### PR TITLE
Clean up print view and prevent chart from landing between a page break

### DIFF
--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -271,6 +271,15 @@ footer {
 }
 
 @media print {
+	.header {
+		max-height: 60px;
+	}
+	.intro-text {
+		display: none;
+	}
+	.extent-map {
+		display: none;
+	}
 	.no-print * {
 		display: none;
 	}

--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -272,15 +272,20 @@ footer {
 
 @media print {
 	.header {
-		max-height: 60px;
-	}
-	.intro-text {
-		display: none;
-	}
-	.extent-map {
-		display: none;
+		max-height: 120px;
 	}
 	.no-print * {
+		display: none;
+	}
+	.extent.section {
+		padding-bottom: 0;
+	}
+	.intro-text {
+		text-align: center;
+		max-width: 100%;
+	}
+	/* Needed for Safari */
+	.extent-wrapper.desktop {
 		display: none;
 	}
 }

--- a/gui.py
+++ b/gui.py
@@ -102,7 +102,7 @@ rcp_radio = html.Div(
 )
 
 download_single_csv = html.Div(
-    className="has-text-centered mb-6",
+    className="has-text-centered mb-6 no-print",
     children=[
         html.Div(
             className="control",
@@ -320,10 +320,12 @@ config = {
 }
 
 camera_icon_text = ddsih.DangerouslySetInnerHTML(
-    """
-<p class="content camera-icon is-size-5 has-text-centered has-text-grey mb-1">Click the <span>
-<svg viewBox="0 0 1000 1000" class="icon" height="1em" width="1em"><path d="m500 450c-83 0-150-67-150-150 0-83 67-150 150-150 83 0 150 67 150 150 0 83-67 150-150 150z m400 150h-120c-16 0-34 13-39 29l-31 93c-6 15-23 28-40 28h-340c-16 0-34-13-39-28l-31-94c-6-15-23-28-40-28h-120c-55 0-100-45-100-100v-450c0-55 45-100 100-100h800c55 0 100 45 100 100v450c0 55-45 100-100 100z m-400-550c-138 0-250 112-250 250 0 138 112 250 250 250 138 0 250-112 250-250 0-138-112-250-250-250z m365 380c-19 0-35 16-35 35 0 19 16 35 35 35 19 0 35-16 35-35 0-19-16-35-35-35z" transform="matrix(1 0 0 -1 0 850)"></path></svg>
-</span> icon in the upper-right of the chart download it.</p>
+"""
+<div class="no-print">
+    <p class="content camera-icon is-size-5 has-text-centered has-text-grey mb-1">Click the <span>
+    <svg viewBox="0 0 1000 1000" class="icon" height="1em" width="1em"><path d="m500 450c-83 0-150-67-150-150 0-83 67-150 150-150 83 0 150 67 150 150 0 83-67 150-150 150z m400 150h-120c-16 0-34 13-39 29l-31 93c-6 15-23 28-40 28h-340c-16 0-34-13-39-28l-31-94c-6-15-23-28-40-28h-120c-55 0-100-45-100-100v-450c0-55 45-100 100-100h800c55 0 100 45 100 100v450c0 55-45 100-100 100z m-400-550c-138 0-250 112-250 250 0 138 112 250 250 250 138 0 250-112 250-250 0-138-112-250-250-250z m365 380c-19 0-35 16-35 35 0 19 16 35 35 35 19 0 35-16 35-35 0-19-16-35-35-35z" transform="matrix(1 0 0 -1 0 850)"></path></svg>
+    </span> icon in the upper-right of the chart download it.</p>
+</div>
 """
 )
 

--- a/gui.py
+++ b/gui.py
@@ -128,11 +128,11 @@ rcp_blurb = ddsih.DangerouslySetInnerHTML(
 )
 
 form_inputs_left = html.Div(
-    className="no-print column is-two-thirds", children=[community_selector, rcp_blurb]
+    className="column is-two-thirds", children=[community_selector, rcp_blurb]
 )
 
 form_inputs_right = html.Div(
-    className="no-print column is-one-third form-inputs-right",
+    className="column is-one-third form-inputs-right",
     children=[dataset_radio, rcp_radio, units_radio],
 )
 
@@ -277,7 +277,7 @@ intro_section = ddsih.DangerouslySetInnerHTML(
     """
     <div class="extent section">
         <div class="intro-text">
-            <div class="extent-wrapper desktop">
+            <div class="extent-wrapper desktop no-print">
                 <img class="extent-map" src="assets/akcanada.svg" />
             </div>
             <h4 class="title is-4 mt-3 mb-5">What’s up — or down — in your corner&nbsp;of&nbsp;the&nbsp;North?</h4>
@@ -286,7 +286,7 @@ intro_section = ddsih.DangerouslySetInnerHTML(
             <p class="my-3">Higher temperatures in spring and fall could mean a longer growing season and/or a shift from&nbsp;snow&nbsp;to&nbsp;rain.</p>
             <p class="my-3">Warmer, drier spring weather may&nbsp;increase&nbsp;fire&nbsp;risk.</p>
             <h5 class="title is-5 mt-5">Happy exploring!</h5>
-            <div class="extent-wrapper mobile">
+            <div class="extent-wrapper mobile no-print">
                 <img class="extent-map" src="assets/akcanada.svg" />
             </div>
         </div>
@@ -320,7 +320,7 @@ config = {
 }
 
 camera_icon_text = ddsih.DangerouslySetInnerHTML(
-"""
+    """
 <div class="no-print">
     <p class="content camera-icon is-size-5 has-text-centered has-text-grey mb-1">Click the <span>
     <svg viewBox="0 0 1000 1000" class="icon" height="1em" width="1em"><path d="m500 450c-83 0-150-67-150-150 0-83 67-150 150-150 83 0 150 67 150 150 0 83-67 150-150 150z m400 150h-120c-16 0-34 13-39 29l-31 93c-6 15-23 28-40 28h-340c-16 0-34-13-39-28l-31-94c-6-15-23-28-40-28h-120c-55 0-100-45-100-100v-450c0-55 45-100 100-100h800c55 0 100 45 100 100v450c0 55-45 100-100 100z m-400-550c-138 0-250 112-250 250 0 138 112 250 250 250 138 0 250-112 250-250 0-138-112-250-250-250z m365 380c-19 0-35 16-35 35 0 19 16 35 35 35 19 0 35-16 35-35 0-19-16-35-35-35z" transform="matrix(1 0 0 -1 0 850)"></path></svg>
@@ -334,13 +334,14 @@ graph_layout = html.Div(
 )
 
 form_container = html.Div(
-    className="form-input section",
+    className="form-input section no-print",
     children=[
         html.Div(
             className="container top",
             children=[
                 html.Div(
-                    className="columns controls-wrapper", children=[form_inputs_left, form_inputs_right]
+                    className="columns controls-wrapper",
+                    children=[form_inputs_left, form_inputs_right],
                 )
             ],
         )


### PR DESCRIPTION
Closes #78.

Since we increased the header height to accommodate a background photo, and added intro text with an extent map, this pushed the chart far enough down the page that it tended to land between two pages in the print preview.

This PR fixes this by:
- Reducing the height of the header section to remove excess whitespace since the background photo is not visible in the print view.
- Hiding the extent map since there's no good place to put it without pushing things further down the page.
- Hiding more interactive elements and instructions that have no purpose on a printed page.

STR:
- Load the app and use your browser's print feature to view the print preview.
- Make sure the chart doesn't fall between a page break.