### PR TITLE
Use text "CRU TS 3.22" instead of "CRU 3.2" to be more clear, and read renamed "cru322" values from CSV input files

### DIFF
--- a/application.py
+++ b/application.py
@@ -82,7 +82,7 @@ def update_graph(community_raw, variable, scenario, units):
     # subset to the data we want to display using the callback variables
 
     if community["region"] == "Northwest Territories":
-        baseline = "cru32"
+        baseline = "cru322"
     else:
         baseline = "prism"
 

--- a/luts.py
+++ b/luts.py
@@ -93,7 +93,7 @@ region_lu = {
     "Yukon": "YT",
 }
 
-resolution_lu = {"cru32": "10min", "prism": "2km"}
+resolution_lu = {"cru322": "10min", "prism": "2km"}
 
 variable_lu = {"temp": "Temperature", "precip": "Precipitation"}
 
@@ -110,7 +110,7 @@ unit_lu = {
     "precip": {"imperial": "in", "metric": "mm"},
 }
 
-baseline_lu = {"cru32": "CRU 3.2", "prism": "PRISM"}
+baseline_lu = {"cru322": "CRU TS 3.22", "prism": "PRISM"}
 
 axis_configs = {
     "automargin": True,


### PR DESCRIPTION
Closes #70.

We have decided to use the term "CRU TS 3.22" instead of just "CRU 3.2" to more accurately describe the dataset we are using for the historical baseline of Northwest Territories. We have also decided to change the scenario value in the CSV files from "cru32" to "cru322" to be more clear.

STR:
- Run `export DATA_PREFIX='https://community-charts-dev.s3.us-west-2.amazonaws.com/'`. The CSV files in this S3 bucket have already been replaced with the new ones that use the "cru322" scenario value.
- Run the app and select a Northwest Territories location.
- Data should show up on the chart and "CRU TS 3.22" should show up in the chart's subtitle.