### PR TITLE
Update CSV download link and add accessibility improvements

### DIFF
--- a/application.py
+++ b/application.py
@@ -277,7 +277,13 @@ def update_download_link(comm):
     community = communities[community_id]
     community_name = full_community_name(community)
     url = path_prefix + "dash/dlCSV?value={}".format(community_id)
-    text = "Download CSV for " + community_name + ", " + community["region"]
+    text = (
+        "Download data for "
+        + community_name
+        + ", "
+        + community["region"]
+        + " as spreadsheet (CSV)"
+    )
     return url, text
 
 

--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -11,6 +11,14 @@ h1, h2, h3, h4, h5, h6 {
 	letter-spacing: .02em;
 }
 
+a {
+	color: #0033cc;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
 label.label:not(:last-child) {
 	margin: 1.5em 0 1ex;
 }
@@ -193,10 +201,6 @@ label.label:not(:last-child) {
 	.form-input.section {
 		padding: 0 150px;
 	}
-}
-
-.form-input a {
-	color: #0033cc;
 }
 
 .form label, .form input {

--- a/gui.py
+++ b/gui.py
@@ -109,7 +109,6 @@ download_single_csv = html.Div(
             className="control",
             children=[
                 html.A(
-                    "Download Single Community (CSV)",
                     className="is-size-5",
                     id="download_single",
                     href="",

--- a/gui.py
+++ b/gui.py
@@ -110,7 +110,7 @@ download_single_csv = html.Div(
             children=[
                 html.A(
                     "Download Single Community (CSV)",
-                    className="button is-info",
+                    className="is-size-5",
                     id="download_single",
                     href="",
                 )


### PR DESCRIPTION
Fixes #88 and #89.

- The CSV download button is now a link using new text, "Download data for [community name] as spreadsheet (CSV)".
- The link color (for the new link and entire page) is now #0033cc to increase contrast.
- An underline has been added to all page links when you hover over them.