### PR TITLE
Center footer logos at narrow resolutions and resize in proportion to each other and the browser.

### DIFF
--- a/assets/99_app.css
+++ b/assets/99_app.css
@@ -270,6 +270,24 @@ footer .logos img {
 	margin-bottom: 1rem;
 }
 
+@media (max-width: 768px) {
+	footer .logos.column {
+		text-align: center;
+	}
+	footer .logos img {
+		margin: 15px;
+	}
+	footer .logos img.nwt {
+		width: 40%;
+	}
+	footer .logos img.uaf {
+		width: 27%;
+	}
+	.footer p {
+		width: 100%;
+	}
+}
+
 footer {
   box-shadow: inset 0 7px 9px -7px rgb(0 0 0 / 40%);
 }

--- a/gui.py
+++ b/gui.py
@@ -208,10 +208,10 @@ footer = html.Footer(
             <div class="columns">
                 <div class="logos column is-one-fifth">
                     <a href="https://www.gov.nt.ca/">
-                        <img src="assets/NWT.svg">
+                        <img class="nwt" src="assets/NWT.svg">
                     </a>
                     <a href="https://uaf.edu/uaf/">
-                        <img src="assets/UAF.svg">
+                        <img class="uaf" src="assets/UAF.svg">
                     </a>
                 </div>
                 <div class="column content is-size-5">

--- a/gui.py
+++ b/gui.py
@@ -207,12 +207,8 @@ footer = html.Footer(
         <div class="container">
             <div class="columns">
                 <div class="logos column is-one-fifth">
-                    <a href="https://www.gov.nt.ca/">
-                        <img class="nwt" src="assets/NWT.svg">
-                    </a>
-                    <a href="https://uaf.edu/uaf/">
-                        <img class="uaf" src="assets/UAF.svg">
-                    </a>
+                    <a href="https://www.gov.nt.ca/"><img class="nwt" src="assets/NWT.svg"></a>
+                    <a href="https://uaf.edu/uaf/"><img class="uaf" src="assets/UAF.svg"></a>
                 </div>
                 <div class="column content is-size-5">
                     <p>This tool is part of an ongoing collaboration between the <a href="https://uaf-snap.org">Scenarios Network for Alaska + Arctic Planning</a> and the Government of Northwest Territories. We are working to make a wide range of downscaled climate products that are easily accessible, flexibly usable, and fully interpreted and understandable to users in the Northwest Territories, while making these products relevant at a broad geographic scale.


### PR DESCRIPTION
Closes #91.

STR:
- Run the app and reduce width of browser to 768px or less.
- The two logos should be centered, next to each other, and approximately the same height. They should also increase/decrease in size based on the browser width.