### PR TITLE
Strip metadata lines from CSV files before parsing CSV data

### DIFF
--- a/application.py
+++ b/application.py
@@ -54,6 +54,17 @@ def full_community_name(community):
     return community["name"]
 
 
+def get_csv(pathname):
+    """Read remote or local CSV file into a string"""
+    if data_prefix.find("http") != -1:
+        with urllib.request.urlopen(pathname) as response:
+            csv = response.read().decode("utf-8")
+    else:
+        with open(pathname, mode="r") as file_handle:
+            csv = file_handle.read()
+    return csv
+
+
 @app.callback(
     Output("ccharts", "figure"),
     inputs=[
@@ -73,16 +84,16 @@ def update_graph(community_raw, variable, scenario, units):
     community_id = filter_community_id(community_raw)
     community = communities[community_id]
     comm_file = data_prefix + "data/" + community_id + ".csv"
+    csv = get_csv(comm_file)
 
     # Strip out metadata lines starting with #
-    csv_content = ""
-    with open(comm_file, "r") as file:
-        for line in file:
-            if not line.startswith("#"):
-                csv_content += line
+    csv_data = ""
+    for line in csv.splitlines():
+        if not line.startswith("#"):
+            csv_data += line + "\n"
 
-    csv_content_io = StringIO(csv_content)
-    df = pd.read_csv(csv_content_io)
+    csv_data_io = StringIO(csv_data)
+    df = pd.read_csv(csv_data_io)
 
     # [ML] maybe hardwire these? Not a huge time sink, but it could be made cleaner
     mean_cols = [col for col in df.columns if "Mean" in col]
@@ -305,13 +316,7 @@ def download_csv():
     community_id = filter_community_id(value)
     community = communities[community_id]
     pathname = data_prefix + "data/" + community_id + ".csv"
-
-    if data_prefix.find("http") != -1:
-        with urllib.request.urlopen(pathname) as response:
-            csv = response.read().decode("utf-8")
-    else:
-        with open(pathname, mode="r") as file_handle:
-            csv = file_handle.read()
+    csv = get_csv(pathname)
 
     community_name = full_community_name(community)
     community_with_region = community_name + ", " + community["region"]

--- a/application.py
+++ b/application.py
@@ -10,6 +10,7 @@ import os
 import urllib.request
 import urllib.parse
 import html as h
+from io import StringIO
 import pandas as pd
 import dash
 from dash.dependencies import Input, Output
@@ -72,7 +73,16 @@ def update_graph(community_raw, variable, scenario, units):
     community_id = filter_community_id(community_raw)
     community = communities[community_id]
     comm_file = data_prefix + "data/" + community_id + ".csv"
-    df = pd.read_csv(comm_file)
+
+    # Strip out metadata lines starting with #
+    csv_content = ""
+    with open(comm_file, "r") as file:
+        for line in file:
+            if not line.startswith("#"):
+                csv_content += line
+
+    csv_content_io = StringIO(csv_content)
+    df = pd.read_csv(csv_content_io)
 
     # [ML] maybe hardwire these? Not a huge time sink, but it could be made cleaner
     mean_cols = [col for col in df.columns if "Mean" in col]


### PR DESCRIPTION
Closes #106.

To test this PR, you will need to use the new CSVs that include metadata produced from the following cc-data-extraction PR: https://github.com/ua-snap/cc-data-extraction/pull/19

Once the above CSV files have been produced, test this PR like this:

```
export FLASK_APP=application.py
export DASH_REQUESTS_PATHNAME_PREFIX='/'
ln -s /path/to/cc-data-extraction/output/csv data
pipenv run flask run
```

Make sure the charts are populated as expected. This means that pandas is successfully reading the CSV data after the metadata lines (prefixed with `#`) have been thrown out.

However, also note that when you download a CSV file via the "Download data..." link below the chart, the metadata lines are included in the downloaded file as planned.

Next, to verify that the app is still able to read CSV files from a remote URL, do this:

```
export DATA_PREFIX='https://s3-us-west-2.amazonaws.com/community-charts/'
pipenv run flask run
```

The charts should still populate like before, but the CSV files downloaded via the "Download data..." link will not have any metadata since it's loading the old/production CSVs from the S3 bucket, as expected.