### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/luts.py
+++ b/luts.py
@@ -3,8 +3,6 @@
 Common shared text strings, formatting defaults and lookup tables.
 """
 
-gtag_id = "UA-3978613-1"
-
 # Core page components
 title = "SNAP Community Climate Charts"
 description = "Explore temperature and precipitation projections for communities across Alaska and Western Canada"

--- a/luts.py
+++ b/luts.py
@@ -20,7 +20,7 @@ index_string = f"""
 <!DOCTYPE html>
 <html>
     <head>
-        <script async defer data-website-id="cc69673a-a302-45ab-ad82-e382c46b0f26" src="https://umami.snap.uaf.edu/umami.js" data-do-not-track="true" data-domains="snap.uaf.edu"></script>
+        <script async defer data-website-id="cc69673a-a302-45ab-ad82-e382c46b0f26" src="https://umami.snap.uaf.edu/script.js" data-do-not-track="true" data-domains="snap.uaf.edu"></script>
         {{%metas%}}
         <title>{{%title%}}</title>
 


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `luts.py` to:

```
<script async defer data-website-id="cc69673a-a302-45ab-ad82-e382c46b0f26" src="http://localhost:9999/script.js" data-do-not-track="true"></script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/cc69673a-a302-45ab-ad82-e382c46b0f26